### PR TITLE
Remove the self recod of Context'

### DIFF
--- a/Data/HashGraph/Algorithms.hs
+++ b/Data/HashGraph/Algorithms.hs
@@ -17,6 +17,7 @@ import Data.HashGraph.Strict
 import Data.HashGraph.Algorithms.MST (prim, primAt)
 import Data.Hashable
 import qualified Data.HashSet as HS
+import Data.Maybe (maybe)
 
 {-
  - Articulation Point
@@ -34,18 +35,14 @@ import qualified Data.HashSet as HS
 
 -- | Breadth-first search
 bfs :: (Eq a, Eq b, Hashable a, Hashable b) => Gr a b -> [b]
-bfs g = case matchAny g of
-    Just (ctx,_) -> snd $ bfs_ g HS.empty [ctx]
-    Nothing -> []
+bfs g = maybe [] (\(ctx,_) -> snd $ bfs_ g HS.empty [ctx]) $ matchAny g
 {-# INLINABLE bfs #-}
 
 bfsn :: (Eq a, Eq b, Hashable a, Hashable b) => b -> Gr a b -> [b]
-bfsn n g = case match n g of
-    Just (ctx,_) -> snd $ bfs_ g HS.empty [(n,ctx)]
-    Nothing -> []
+bfsn n g = maybe [] (\(ctx,_) -> snd $ bfs_ g HS.empty [ctx]) $ match n g
 {-# INLINABLE bfsn #-}
 
-bfs_ :: (Eq b, Hashable b) => Gr a b -> HS.HashSet b -> [(b,Context' a b)] -> (HS.HashSet b, [b])
+bfs_ :: (Eq b, Hashable b) => Gr a b -> HS.HashSet b -> [Context a b] -> (HS.HashSet b, [b])
 bfs_ _ set [] = (set, [])
 bfs_ g !set cs =
     (\(newSet, parents, kids) ->
@@ -61,18 +58,14 @@ bfs_ g !set cs =
 
 -- | Depth-first search
 dfs :: (Eq a, Eq b, Hashable a, Hashable b) => Gr a b -> [b]
-dfs g = case matchAny g of
-    Just (ctx,_) -> snd $ dfs_ g HS.empty ctx
-    Nothing -> []
+dfs g = maybe [] (snd . dfs_ g HS.empty . fst) $ matchAny g
 {-# INLINABLE dfs #-}
 
 dfsn :: (Eq a, Eq b, Hashable a, Hashable b) => b -> Gr a b -> [b]
-dfsn n g = case match n g of
-    Just (ctx,_) -> snd $ dfs_ g HS.empty (n,ctx)
-    Nothing -> []
+dfsn n g = maybe [] (snd . dfs_ g HS.empty . fst) $ match n g
 {-# INLINABLE dfsn #-}
 
-dfs_ :: (Eq b, Hashable b) => Gr a b -> HS.HashSet b -> (b,Context' a b) -> (HS.HashSet b, [b])
+dfs_ :: (Eq b, Hashable b) => Gr a b -> HS.HashSet b -> Context a b -> (HS.HashSet b, [b])
 dfs_ g !set (n,Context' _ ss)
   = if HS.member n set
        then (set,[])

--- a/Data/HashGraph/Algorithms.hs
+++ b/Data/HashGraph/Algorithms.hs
@@ -41,21 +41,19 @@ bfs g = case matchAny g of
 
 bfsn :: (Eq a, Eq b, Hashable a, Hashable b) => b -> Gr a b -> [b]
 bfsn n g = case match n g of
-    Just (ctx,_) -> snd $ bfs_ g HS.empty [ctx]
+    Just (ctx,_) -> snd $ bfs_ g HS.empty [(n,ctx)]
     Nothing -> []
 {-# INLINABLE bfsn #-}
 
-bfs_ :: (Eq b, Hashable b) => Gr a b -> HS.HashSet b -> [Context' a b] -> (HS.HashSet b, [b])
+bfs_ :: (Eq b, Hashable b) => Gr a b -> HS.HashSet b -> [(b,Context' a b)] -> (HS.HashSet b, [b])
 bfs_ _ set [] = (set, [])
-bfs_ g initialSet initialContext = go initialSet initialContext
+bfs_ g !set cs =
+    (\(newSet, parents, kids) ->
+      (\(resSet, resNodes) -> (resSet, parents ++ resNodes)) (bfs_ g newSet kids)) $ foldl' helper (set,[],[]) cs
   where
-    go set [] = (set, [])
-    go !set cs =
-        (\(newSet, parents, kids) ->
-            (\(resSet, resNodes) -> (resSet, parents ++ resNodes)) (go newSet kids)) $ foldl' helper (set,[],[]) cs
-    helper (hs,ps,ctxs) (Context' _ n ss) = if HS.member n hs
+    helper (hs,ps,ctxs) (n,Context' _ ss) = if HS.member n hs
         then (hs,ps,ctxs)
-        else (HS.insert n hs, n:ps, map (\(Tail _ s) -> g!s) (HS.toList ss) ++ ctxs)
+        else (HS.insert n hs, n:ps, map (\(Tail _ s) -> (s,g!s)) (HS.toList ss) ++ ctxs)
 {-# INLINABLE bfs_ #-}
 
 -----------------------------------
@@ -70,17 +68,18 @@ dfs g = case matchAny g of
 
 dfsn :: (Eq a, Eq b, Hashable a, Hashable b) => b -> Gr a b -> [b]
 dfsn n g = case match n g of
-    Just (ctx,_) -> snd $ dfs_ g HS.empty ctx
+    Just (ctx,_) -> snd $ dfs_ g HS.empty (n,ctx)
     Nothing -> []
 {-# INLINABLE dfsn #-}
 
-dfs_ :: (Eq b, Hashable b) => Gr a b -> HS.HashSet b -> Context' a b -> (HS.HashSet b, [b])
-dfs_ g = go
-  where
-    go !set (Context' _ n ss) = if HS.member n set
-        then (set,[])
-        else let (newSet, lst) = HS.foldl' (\(hs,ls) (Tail _ s) -> (\(dSet,dNodes) -> (dSet, dNodes ++ ls)) (go hs (g!s)))
-                                       (HS.insert n set,[]) ss
+dfs_ :: (Eq b, Hashable b) => Gr a b -> HS.HashSet b -> (b,Context' a b) -> (HS.HashSet b, [b])
+dfs_ g !set (n,Context' _ ss)
+  = if HS.member n set
+       then (set,[])
+       else let (newSet, lst) = HS.foldl'
+                                  (\(hs,ls) (Tail _ s) -> (\(dSet,dNodes) -> (dSet, dNodes ++ ls)) (dfs_ g hs (s,g!s)))
+                                  (HS.insert n set,[])
+                                  ss
              in (newSet, n : lst)
 {-# INLINABLE dfs_ #-}
 

--- a/Data/HashGraph/Algorithms/MST.hs
+++ b/Data/HashGraph/Algorithms/MST.hs
@@ -28,11 +28,10 @@ primAt start g = maybe g (primBoth g . (start,)) $ g !? start
 --------------------------------------
 -- Use just an optimal hash-map
 
-primMap :: (Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> (b,Context' a b) -> Gr a b
+primMap :: (Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> Context a b -> Gr a b
 primMap g (node,Context' _ sucs) = fixTails $ go HS.empty HM.empty (node,Context' HS.empty sucs)
   where
     -- Context has new ps (just the edge that was used to include this node) and old ss
-    --go :: HS.HashSet b -> HM.HashMap b (Head a b) -> (b,Context' a b) -> [(b, Context' a b)]
     go !visited !optimal (n,Context' ps ss) =
         let newVisited = HS.insert n visited
         in case pickNextNode (addTailsMap n newVisited optimal ss) of
@@ -78,7 +77,7 @@ minHead hd1@(Head l1 _) hd2@(Head l2 _) = if l1 < l2 then hd1 else hd2
 ----------------------------------
 -- Use just a min-heap
 
-primHeap :: (Eq a, Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> (b,Context' a b) -> Gr a b
+primHeap :: (Eq a, Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> Context a b -> Gr a b
 primHeap g (node,Context' _ sucs) = fixTails $ go (order g - 1) HS.empty H.empty (node,Context' HS.empty sucs)
   where
     go 0 _ _ _ = []
@@ -108,7 +107,7 @@ addTailsHeap p visited = HS.foldl' checkedInsert
 ----------------------------------
 -- Use both!
 
-primBoth :: (Eq a, Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> (b,Context' a b) -> Gr a b
+primBoth :: (Eq a, Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> Context a b -> Gr a b
 primBoth g (node,Context' _ sucs) = fixTails $ go HS.empty HM.empty H.empty (node,Context' HS.empty sucs)
   where
     go !visited !optimal !edgeHeap (n,Context' ps ss) =

--- a/Data/HashGraph/Algorithms/MST.hs
+++ b/Data/HashGraph/Algorithms/MST.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BangPatterns, TupleSections #-}
 
 module Data.HashGraph.Algorithms.MST (
     prim
@@ -12,6 +12,7 @@ import qualified Data.HashSet as HS
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Heap as H
 import Data.List (foldl')
+import Data.Maybe (maybe)
 
 -- | Prim's algorithm for the minimum spanning tree
 --
@@ -19,30 +20,27 @@ import Data.List (foldl')
 -- optimal edges
 
 prim :: (Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> Gr a b
-prim g = case matchAny g of
-    Just (ctx, _) -> primBoth g ctx
-    Nothing -> g
+prim g = maybe g (primBoth g . fst) $ matchAny g
 
 primAt :: (Eq b, Hashable a, Hashable b, Ord a) => b -> Gr a b -> Gr a b
-primAt start g = case g !? start of
-    Just ctx -> primBoth g ctx
-    Nothing -> g
+primAt start g = maybe g (primBoth g . (start,)) $ g !? start
 
 --------------------------------------
 -- Use just an optimal hash-map
 
-primMap :: (Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> Context' a b -> Gr a b
-primMap g (Context' _ node sucs) = fixTails $ go HS.empty HM.empty (Context' HS.empty node sucs)
+primMap :: (Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> (b,Context' a b) -> Gr a b
+primMap g (node,Context' _ sucs) = fixTails $ go HS.empty HM.empty (node,Context' HS.empty sucs)
   where
     -- Context has new ps (just the edge that was used to include this node) and old ss
-    go !visited !optimal (Context' ps n ss) =
+    --go :: HS.HashSet b -> HM.HashMap b (Head a b) -> (b,Context' a b) -> [(b, Context' a b)]
+    go !visited !optimal (n,Context' ps ss) =
         let newVisited = HS.insert n visited
         in case pickNextNode (addTailsMap n newVisited optimal ss) of
-            Just (newOpt, newCtx) -> (n, Context' ps n HS.empty) : go newVisited newOpt newCtx
-            Nothing -> [(n, Context' ps n HS.empty)]
+            Just (newOpt, newCtx) -> (n, Context' ps HS.empty) : go newVisited newOpt newCtx
+            Nothing -> [(n, Context' ps HS.empty)]
     -- remove picked node from optimal and prep it for next round
     pickNextNode opt
-        = (\(s,hd) -> (HM.delete s opt, Context' (HS.singleton hd) s (tails (g ! s)))) <$> minimumByWeight opt
+      = (\(s,hd) -> (HM.delete s opt, (s, Context' (HS.singleton hd) (tails (g ! s))))) <$> minimumByWeight opt
 
 -- Add all new edges to the optimal map, keeping only better ones
 addTailsMap :: (Eq b, Hashable b, Ord a) => b                          -- New node
@@ -80,21 +78,19 @@ minHead hd1@(Head l1 _) hd2@(Head l2 _) = if l1 < l2 then hd1 else hd2
 ----------------------------------
 -- Use just a min-heap
 
-primHeap :: (Eq a, Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> Context' a b -> Gr a b
-primHeap g (Context' _ node sucs) = fixTails $ go (order g - 1) HS.empty H.empty (Context' HS.empty node sucs)
+primHeap :: (Eq a, Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> (b,Context' a b) -> Gr a b
+primHeap g (node,Context' _ sucs) = fixTails $ go (order g - 1) HS.empty H.empty (node,Context' HS.empty sucs)
   where
     go 0 _ _ _ = []
-    go count !visited !edgeHeap (Context' ps n ss) =
+    go count !visited !edgeHeap (n,Context' ps ss) =
         let newVisited = HS.insert n visited
         in case pickNextEdge newVisited (addTailsHeap n newVisited edgeHeap ss) of
-            Just (newEdgeHeap, newCtx) -> (n, Context' ps n HS.empty) : go (count - 1) newVisited newEdgeHeap newCtx
-            Nothing -> [(n, Context' ps n HS.empty)]
-    pickNextEdge visited edgeHeap = case H.uncons edgeHeap of
-        Just (Edge p l s, newHeap) ->
+            Just (newEdgeHeap, newCtx) -> (n, Context' ps HS.empty) : go (count - 1) newVisited newEdgeHeap newCtx
+            Nothing -> [(n, Context' ps HS.empty)]
+    pickNextEdge visited edgeHeap = H.uncons edgeHeap >>= \(Edge p l s, newHeap) ->
             if HS.member s visited
                 then pickNextEdge visited newHeap
-                else Just (newHeap, Context' (HS.singleton (Head l p)) s (tails (g!s)))
-        Nothing -> Nothing
+                else Just (newHeap, (s,Context' (HS.singleton (Head l p)) (tails (g!s))))
 
 addTailsHeap :: (Eq b, Hashable b, Ord a)
          => b
@@ -112,21 +108,19 @@ addTailsHeap p visited = HS.foldl' checkedInsert
 ----------------------------------
 -- Use both!
 
-primBoth :: (Eq a, Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> Context' a b -> Gr a b
-primBoth g (Context' _ node sucs) = fixTails $ go HS.empty HM.empty H.empty (Context' HS.empty node sucs)
+primBoth :: (Eq a, Eq b, Hashable a, Hashable b, Ord a) => Gr a b -> (b,Context' a b) -> Gr a b
+primBoth g (node,Context' _ sucs) = fixTails $ go HS.empty HM.empty H.empty (node,Context' HS.empty sucs)
   where
-    go !visited !optimal !edgeHeap (Context' ps n ss) =
+    go !visited !optimal !edgeHeap (n,Context' ps ss) =
         let newVisited = HS.insert n visited
         in case pickNextEdge newVisited (addTailsBoth n newVisited optimal edgeHeap ss) of
-            Just (newEdgeHeap, newOpt, newCtx) -> (n, Context' ps n HS.empty) : go newVisited newOpt newEdgeHeap newCtx
-            Nothing -> [(n, Context' ps n HS.empty)]
-    pickNextEdge visited (opt, edgeHeap) | HM.null opt = Nothing
-                                         | otherwise = case H.uncons edgeHeap of
-        Just (Edge p l s, newHeap) ->
-            if HS.member s visited
-                then pickNextEdge visited (opt, newHeap)
-                else Just (newHeap, HM.delete s opt, Context' (HS.singleton (Head l p)) s (tails (g!s)))
-        Nothing -> Nothing
+            Just (newEdgeHeap, newOpt, newCtx) -> (n, Context' ps HS.empty) : go newVisited newOpt newEdgeHeap newCtx
+            Nothing -> [(n, Context' ps HS.empty)]
+    pickNextEdge visited (opt, edgeHeap)
+      | HM.null opt = Nothing
+      | otherwise = H.uncons edgeHeap >>= \(Edge p l s, newHeap) -> if HS.member s visited
+                                                      then pickNextEdge visited (opt, newHeap)
+                                                      else Just (newHeap, HM.delete s opt, (s,Context' (HS.singleton (Head l p)) (tails (g!s))))
 
 addTailsBoth :: (Eq b, Hashable b, Ord a)
          => b

--- a/Data/HashGraph/Algorithms/MST.hs
+++ b/Data/HashGraph/Algorithms/MST.hs
@@ -68,7 +68,7 @@ minimumByWeight
 -- The generated list does not have any tails, match all the heads with tails
 fixTails :: (Eq a, Eq b, Hashable a, Hashable b) => [(b, Context' a b)] -> Gr a b
 fixTails ls
-    = let es = foldl' (\es' (s, Context' ps _ _) -> map (\(Head l p) -> Edge p l s) (HS.toList ps) ++ es') [] ls
+    = let es = foldl' (\es' (s, Context' ps _) -> map (\(Head l p) -> Edge p l s) (HS.toList ps) ++ es') [] ls
       in Gr $ foldl' (flip insTail) (HM.fromList ls) es
 
 minEdge :: Ord a => (b, Head a b) -> (b, Head a b) -> (b, Head a b)

--- a/Data/HashGraph/Strict.hs
+++ b/Data/HashGraph/Strict.hs
@@ -193,8 +193,8 @@ match n g = g !? n >>= \ctx -> Just (ctx, delCtx n ctx g)
 {-# INLINE match #-}
 
 -- | Extract any node from the graph
-matchAny :: (Eq a, Eq b, Hashable a, Hashable b) => Gr a b -> Maybe (Context' a b, Gr a b)
-matchAny g = L.uncons (toList g) >>= \((l,ctx),_) -> Just (ctx, delCtx l ctx g)
+matchAny :: (Eq a, Eq b, Hashable a, Hashable b) => Gr a b -> Maybe ((b,Context' a b), Gr a b)
+matchAny g = L.uncons (toList g) >>= \((l,ctx),_) -> Just ((l,ctx), delCtx l ctx g)
 {-# INLINE matchAny #-}
 
 infixr 9 &

--- a/Data/HashGraph/Strict.hs
+++ b/Data/HashGraph/Strict.hs
@@ -200,8 +200,8 @@ infixr 9 &
 -- TODO: Figure out how this should be implemented
 -- | Merge the 'Context' into the graph
 -- Currently deletes old node if present
-(&) :: (Eq a, Eq b, Hashable a, Hashable b) => b -> Context' a b -> Gr a b -> Gr a b
-(&) l ctx (Gr g) = Gr $ HM.insert l ctx g
+(&) :: (Eq a, Eq b, Hashable a, Hashable b) => Context a b -> Gr a b -> Gr a b
+(&) (l,ctx) (Gr g) = Gr $ HM.insert l ctx g
 
 --------------------------------------
 -- Maps
@@ -348,8 +348,8 @@ safeInsNode n g
       else insNode n g
 
 -- | Insert a node, using the combining function if it already exists
-insNodeWith :: (Eq b, Hashable b) => (Context' a b -> Context' a b -> Context' a b) -> b -> Context' a b -> Gr a b -> Gr a b
-insNodeWith f n c (Gr g) = Gr $ HM.insertWith f n c g
+insNodeWith :: (Eq b, Hashable b) => (Context' a b -> Context' a b -> Context' a b) -> Context a b -> Gr a b -> Gr a b
+insNodeWith f (n,c) (Gr g) = Gr $ HM.insertWith f n c g
 
 -- | Remove a node and its edges
 delNode :: (Eq a, Eq b, Hashable a, Hashable b) => b -> Gr a b -> Gr a b
@@ -424,18 +424,18 @@ delTails s (Context' ps _) g = HS.foldl' go g ps
 
 -- | /O(n)/ Return a list of this graph's elements. The list is
 -- produced lazily. The order of its elements is unspecified.
-toList :: Gr a b -> [(b, Context' a b)]
+toList :: Gr a b -> [Context a b]
 toList (Gr g) = HM.toList g
 
 -- | /O(n)/ Construct a graph with the supplied structure. If the
 -- list contains duplicate nodes, the later edges take precedence.
-fromList :: (Eq b, Hashable b) => [(b, Context' a b)] -> Gr a b
+fromList :: (Eq b, Hashable b) => [Context a b] -> Gr a b
 fromList = Gr . HM.fromList
 {-# INLINE fromList #-}
 
 -- | /O(n*log n)/ Construct a graph with the supplied structure. Uses
 -- the provided function to merge duplicate entries.
-fromListWith :: (Eq b, Hashable b) => (Context' a b -> Context' a b -> Context' a b) -> [(b, Context' a b)] -> Gr a b
+fromListWith :: (Eq b, Hashable b) => (Context' a b -> Context' a b -> Context' a b) -> [Context a b] -> Gr a b
 fromListWith f = Gr . HM.fromListWith f
 
 ------------------------------------

--- a/benchmarks/Benchmark.hs
+++ b/benchmarks/Benchmark.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Main where
 
 -- New library imports
@@ -64,15 +66,15 @@ fgl n = let graph = buildOld (oldEdges n) (oldNodes n) in
     -- Queries
     , bgroup "queries"
       [ bench "member"        $ whnf (Old.gelem (n-1)) graph
-      , bench "neighbors"     $ nf ((flip Old.neighbors) (n-1)) graph
-      , bench "preds"         $ nf ((flip Old.pre) (n-1)) graph
-      , bench "succs"         $ nf ((flip Old.suc) (n-1)) graph
-      , bench "inEdges"       $ nf ((flip Old.inn) (n-1)) graph
-      , bench "outEdges"      $ nf ((flip Old.out) (n-1)) graph
-      , bench "inDegree"      $ whnf ((flip Old.indeg) (n-1)) graph
-      , bench "outDegree"     $ whnf ((flip Old.outdeg) (n-1)) graph
-      , bench "degree"        $ whnf ((flip Old.deg) (n-1)) graph
-      , bench "hasEdge"       $ whnf ((flip Old.hasEdge) (n-1,n-2)) graph
+      , bench "neighbors"     $ nf (flip Old.neighbors (n-1)) graph
+      , bench "preds"         $ nf (flip Old.pre (n-1)) graph
+      , bench "succs"         $ nf (flip Old.suc (n-1)) graph
+      , bench "inEdges"       $ nf (flip Old.inn (n-1)) graph
+      , bench "outEdges"      $ nf (flip Old.out (n-1)) graph
+      , bench "inDegree"      $ whnf (flip Old.indeg (n-1)) graph
+      , bench "outDegree"     $ whnf (flip Old.outdeg (n-1)) graph
+      , bench "degree"        $ whnf (flip Old.deg (n-1)) graph
+      , bench "hasEdge"       $ whnf (flip Old.hasEdge (n-1,n-2)) graph
       , bench "hasNeighbor"   $ whnf ((\x y z -> Old.hasNeighbor z x y) (n-1) (n-2)) graph
       ]
 
@@ -100,7 +102,7 @@ fgl n = let graph = buildOld (oldEdges n) (oldNodes n) in
     -- Algorithms
     , bgroup "algorithms"
       [ bench "bfs" $ nf (Old.bfs (n-1)) graph
-      , bench "dfs" $ nf (Old.dfs [(n-1)]) graph
+      , bench "dfs" $ nf (Old.dfs [n-1]) graph
       , bench "mst" $ nf (Old.msTreeAt n) graph
       ]
     ]
@@ -134,7 +136,7 @@ hashGraph n = let graph = G.fromList (listGraph n) in
       , bench "(!?)"     $ whnf (G.!? n)  graph
       , bench "match"    $ nf (G.match n) graph
       , bench "matchAny" $ nf G.matchAny graph
-      , bench "(&)"      $ whnf ((G.Context' (HS.empty) (n+1) (HS.empty)) G.&) graph
+      , bench "(&)"      $ whnf ((n+1,G.Context' HS.empty HS.empty) G.&) graph
       ]
 
     -- Maps
@@ -271,9 +273,8 @@ oldCtxts n = first : [([(n'*n'',n'') | n'' <- [1..n']], n', n', [(n'*n'',n'') | 
 newEdges :: Int -> [G.Edge Int Int]
 newEdges n = tail $ (\x y -> G.Edge x (x*y) y) <$> [1..n] <*> [1..n]
 
-listGraph :: Int -> [(Int, G.Context' Int Int)]
+listGraph :: Int -> [G.Context Int Int]
 listGraph n = first : [ (n', G.Context' (HS.fromList [G.Head (n'*n'') n'' | n'' <- [1..n]])
-                                        n'
                                         (HS.fromList [G.Tail (n'*n'') n'' | n'' <- [1..n]])) | n' <- [2..n] ]
   where
-    first = (1, G.Context' (HS.fromList [G.Head n'' n'' | n'' <- [2..n]]) 1 (HS.fromList [G.Tail n'' n'' | n'' <- [2..n]]))
+    first = (1, G.Context' (HS.fromList [G.Head n'' n'' | n'' <- [2..n]]) (HS.fromList [G.Tail n'' n'' | n'' <- [2..n]]))

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -76,26 +76,26 @@ library = describe "Strict Graphs" $ do
         describe "match" $ do
             let gr = G.mkGraph [] ['a'] :: TestGraph
             it "finds and removes nodes in the graph" $
-                G.match 'a' gr `shouldBe` Just (G.Context' HS.empty 'a' HS.empty, G.empty)
+                G.match 'a' gr `shouldBe` Just (G.Context' HS.empty HS.empty, G.empty)
             it "doesn't find nodes not in the graph" $
                 G.match 'b' gr `shouldBe` Nothing
         describe "matchAny" $ do
             let gr = G.mkGraph [] ['a'] :: TestGraph
             it "finds nodes when the graph is non-empty" $
-                G.matchAny gr `shouldBe` Just (G.Context' HS.empty 'a' HS.empty, G.empty)
+                G.matchAny gr `shouldBe` Just (('a', G.Context' HS.empty HS.empty), G.empty)
             it "does not find a node when the graph is empty" $
                 G.matchAny (G.empty :: TestGraph) `shouldBe` Nothing
         --describe "(&)" $ do
         describe "(!)" $ do
             let gr = G.mkGraph [] ['a'] :: TestGraph
             it "finds nodes in the graph" $
-                gr G.! 'a' `shouldBe` G.Context' HS.empty 'a' HS.empty
+                gr G.! 'a' `shouldBe` G.Context' HS.empty HS.empty
             it "doesn't find nodes not in the graph" $
                 evaluate (gr G.! 'b') `shouldThrow` errorCall "Data.Graph.Inductive.Strict.(!): node not found"
         describe "(!?)" $ do
             let gr = G.mkGraph [] ['a'] :: TestGraph
             it "finds nodes in the graph" $
-                gr G.!? 'a' `shouldBe` Just (G.Context' HS.empty 'a' HS.empty)
+                gr G.!? 'a' `shouldBe` Just (G.Context' HS.empty HS.empty)
             it "doesn't find nodes not in the graph" $
                 gr G.!? 'b' `shouldBe` Nothing
         describe "nodes" $

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -76,7 +76,7 @@ library = describe "Strict Graphs" $ do
         describe "match" $ do
             let gr = G.mkGraph [] ['a'] :: TestGraph
             it "finds and removes nodes in the graph" $
-                G.match 'a' gr `shouldBe` Just (G.Context' HS.empty HS.empty, G.empty)
+                G.match 'a' gr `shouldBe` Just (('a',G.Context' HS.empty HS.empty), G.empty)
             it "doesn't find nodes not in the graph" $
                 G.match 'b' gr `shouldBe` Nothing
         describe "matchAny" $ do


### PR DESCRIPTION
As discussed in #12 

Maybe there is a design issue with the introduction of `type Context a b = (b,Context' a b)`: Do we want/need to re-write the type of functions with a type like `b -> Context' a b` with `Context a b` ?

About the `(&)` I chose to use `Context  a b`, as I think it will allow a cleaner syntax (anyway, the operator is not used _at all_ in the project)

I also removed the `contexts` function since I do not used it any more and I think it can now introduce more problems than solutions :)